### PR TITLE
Adds course syllabus

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,9 +82,8 @@
                                     <td><a href="https://github.com/cs342">http://github.com/cs342</a></td>
                                 </tr>
                                 <tr>
-                                    <td>Sign Up</td>
-                                    <td><a href="https://explorecourses.stanford.edu/search?view=catalog&filter-coursestatus-Active=on&page=0&catalog=&academicYear=&q=cs342&collapse=">CS342/MED253 at explorecourses.stanford.edu</a>
-                                    </td>
+                                    <td>Syllabus</td>
+                                    <td><a href="https://docs.google.com/document/d/1wUvFQ7rlDyQ3DJK9uCYKiZ31e7L6wb17JM52-Z8K3ZA/edit">View Course Syllabus on Google Docs</a></td>
                                 </tr>
                             </tbody>
                         </table>


### PR DESCRIPTION
<!--

This source file is part of the Stanford CS342 - Building for Digital Health class

SPDX-FileCopyrightText: 2022 Stanford University

SPDX-License-Identifier: MIT

-->

# Adds course syllabus

Adds a link to the official course syllabus on Google Docs to the homepage. Replaces the sign up link since registration is now closed.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).

