### PR TITLE
Add redirect to RFP on Notion

### DIFF
--- a/rfp/index.html
+++ b/rfp/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Redirecting...</title>
+    <!-- Redirects the page after 0 seconds -->
+    <meta http-equiv="refresh" content="0;url=https://stanfordbdhg.notion.site/CS342-Request-for-Proposal-d86ac9fcd1c74c238123612c3e60c373">
+</head>
+<body>
+    <!-- Optional: Message displayed before the redirection occurs -->
+    <p>If you are not redirected, <a href="https://stanfordbdhg.notion.site/CS342-Request-for-Proposal-d86ac9fcd1c74c238123612c3e60c373">click here</a>.</p>
+</body>
+</html>


### PR DESCRIPTION
Allows users to find the RFP for the Winter 2024 Session by going to `/rfp`.