### PR TITLE
Add redirects for faculty and partner pages

### DIFF
--- a/faculty/index.html
+++ b/faculty/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Redirecting...</title>
+    <!-- Redirects the page after 0 seconds -->
+    <meta http-equiv="refresh" content="0;url=https://stanfordbdhg.notion.site/CS342-MED253-Faculty-Projects-4e932ca6d88249d2a3d5e8c7c72b0294">
+</head>
+<body>
+    <p>If you are not redirected, <a href="https://stanfordbdhg.notion.site/CS342-MED253-Faculty-Projects-4e932ca6d88249d2a3d5e8c7c72b0294">click here</a>.</p>
+</body>
+</html>

--- a/partner/index.html
+++ b/partner/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Redirecting...</title>
+    <!-- Redirects the page after 0 seconds -->
+    <meta http-equiv="refresh" content="0;url=https://stanfordbdhg.notion.site/CS342-MED253-Partnership-Program-144e7cf4268a49cd9de945026cc98d28">
+</head>
+<body>
+    <p>If you are not redirected, <a href="https://stanfordbdhg.notion.site/CS342-MED253-Partnership-Program-144e7cf4268a49cd9de945026cc98d28">click here</a>.</p>
+</body>
+</html>

--- a/rfp/index.html
+++ b/rfp/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="refresh" content="0;url=https://stanfordbdhg.notion.site/CS342-Request-for-Proposal-d86ac9fcd1c74c238123612c3e60c373">
 </head>
 <body>
-    <!-- Optional: Message displayed before the redirection occurs -->
     <p>If you are not redirected, <a href="https://stanfordbdhg.notion.site/CS342-Request-for-Proposal-d86ac9fcd1c74c238123612c3e60c373">click here</a>.</p>
 </body>
 </html>


### PR DESCRIPTION
<!--

This source file is part of the Stanford CS342 - Building for Digital Health class

SPDX-FileCopyrightText: 2022 Stanford University

SPDX-License-Identifier: MIT

-->

# Add redirects for faculty and partner pages

## :recycle: Current situation & Problem
Redirects `/partner` and `/faculty` to the corresponding pages on Notion for the purpose of making shortlinks to distribute.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).

